### PR TITLE
tetris: update ImsService.apk hash for latest NothingOS 3.2 OTA

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -1515,7 +1515,7 @@ vendor/lib64/hw/vendor.mediatek.hardware.videotelephony-impl.so
 vendor/lib64/vendor.mediatek.hardware.videotelephony-V1-ndk.so
 
 # ImsService - from zahedan U
--system_ext/priv-app/ImsService/ImsService.apk|e0390f357ce63afa3c1d4ff8f5d9258d6d4bc2f6
+-system_ext/priv-app/ImsService/ImsService.apk|9dff0826b674c0752050a79a60d278a8fc46e3b5
 
 # Keymint
 vendor/bin/hw/android.hardware.secure_element@1.2-service-mediatek


### PR DESCRIPTION
Updates hash for `system_ext/priv-app/ImsService/ImsService.apk` in `proprietary-files.txt.`

Fixes extraction hash mismatch on NothingOS 3.2 OTA (`Tetris-V3.2-250925-1843-EEA`).

Allows `extract-files.sh` to complete and ROM builds to succeed.